### PR TITLE
Last Batch of Quiche.NET fixes

### DIFF
--- a/Subverse.Server/PeerBootstrapService.cs
+++ b/Subverse.Server/PeerBootstrapService.cs
@@ -142,8 +142,6 @@ internal class PeerBootstrapService : BackgroundService
                             MaxInitialBidiStreams = 16,
                             MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                             MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
-
-                            MaxIdleTimeout = 30_000,
                         };
 
                         clientConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/PeerBootstrapService.cs
+++ b/Subverse.Server/PeerBootstrapService.cs
@@ -143,7 +143,7 @@ internal class PeerBootstrapService : BackgroundService
                             MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                             MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
 
-                            MaxIdleTimeout = 15_000,
+                            MaxIdleTimeout = 10_000,
                         };
 
                         clientConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/PeerBootstrapService.cs
+++ b/Subverse.Server/PeerBootstrapService.cs
@@ -143,7 +143,7 @@ internal class PeerBootstrapService : BackgroundService
                             MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                             MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
 
-                            MaxIdleTimeout = 15_000,
+                            MaxIdleTimeout = 45_000,
                         };
 
                         clientConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/PeerBootstrapService.cs
+++ b/Subverse.Server/PeerBootstrapService.cs
@@ -23,7 +23,7 @@ internal class PeerBootstrapService : BackgroundService
 
     private readonly IConfiguration _configuration;
     private readonly ILogger<PeerBootstrapService> _logger;
-    private readonly ILoggerProvider _loggerProvider;
+    private readonly ILoggerFactory _loggerFactory;
     private readonly IPeerService _peerService;
 
     private readonly HttpClient _http;
@@ -35,7 +35,7 @@ internal class PeerBootstrapService : BackgroundService
 
     private bool disposedValue;
 
-    public PeerBootstrapService(IConfiguration configuration, ILogger<PeerBootstrapService> logger, ILoggerProvider loggerProvider, IPeerService hubService)
+    public PeerBootstrapService(IConfiguration configuration, ILogger<PeerBootstrapService> logger, ILoggerFactory loggerFactory, IPeerService hubService)
     {
         _configuration = configuration;
 
@@ -43,7 +43,7 @@ internal class PeerBootstrapService : BackgroundService
             ?? DEFAULT_CONFIG_BOOTSTRAP_API;
 
         _logger = logger;
-        _loggerProvider = loggerProvider;
+        _loggerFactory = loggerFactory;
         _peerService = hubService;
 
         _http = new HttpClient()
@@ -152,7 +152,7 @@ internal class PeerBootstrapService : BackgroundService
                         socket.Bind(new IPEndPoint(IPAddress.Any, 0));
 
                         var quicheConnection = QuicheConnection.Connect(socket, remoteEndPoint, clientConfig, hostname);
-                        QuichePeerConnection peerConnection = new(_loggerProvider.CreateLogger("QuicheConnection"), quicheConnection);
+                        QuichePeerConnection peerConnection = new(_loggerFactory.CreateLogger<QuichePeerConnection>(), quicheConnection);
 
                         _connectionMap.AddOrUpdate(hostname, peerConnection,
                             (key, oldConnection) =>

--- a/Subverse.Server/PeerBootstrapService.cs
+++ b/Subverse.Server/PeerBootstrapService.cs
@@ -142,7 +142,7 @@ internal class PeerBootstrapService : BackgroundService
                             MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                             MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
 
-                            MaxIdleTimeout = 20_000,
+                            MaxIdleTimeout = 30_000,
                         };
 
                         clientConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/PeerBootstrapService.cs
+++ b/Subverse.Server/PeerBootstrapService.cs
@@ -141,7 +141,9 @@ internal class PeerBootstrapService : BackgroundService
 
                             MaxInitialBidiStreams = 16,
                             MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
-                            MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN
+                            MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
+
+                            MaxIdleTimeout = 10_000,
                         };
 
                         clientConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/PeerBootstrapService.cs
+++ b/Subverse.Server/PeerBootstrapService.cs
@@ -142,7 +142,7 @@ internal class PeerBootstrapService : BackgroundService
                             MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                             MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
 
-                            MaxIdleTimeout = 30_000,
+                            MaxIdleTimeout = 60_000,
                         };
 
                         clientConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/PeerBootstrapService.cs
+++ b/Subverse.Server/PeerBootstrapService.cs
@@ -142,8 +142,6 @@ internal class PeerBootstrapService : BackgroundService
                             MaxInitialBidiStreams = 16,
                             MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                             MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
-
-                            MaxIdleTimeout = 15_000,
                         };
 
                         clientConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/PeerBootstrapService.cs
+++ b/Subverse.Server/PeerBootstrapService.cs
@@ -141,9 +141,7 @@ internal class PeerBootstrapService : BackgroundService
 
                             MaxInitialBidiStreams = 16,
                             MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
-                            MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
-
-                            MaxIdleTimeout = 10_000,
+                            MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN
                         };
 
                         clientConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/PeerBootstrapService.cs
+++ b/Subverse.Server/PeerBootstrapService.cs
@@ -142,6 +142,8 @@ internal class PeerBootstrapService : BackgroundService
                             MaxInitialBidiStreams = 16,
                             MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                             MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
+
+                            MaxIdleTimeout = 15_000,
                         };
 
                         clientConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/PeerBootstrapService.cs
+++ b/Subverse.Server/PeerBootstrapService.cs
@@ -143,7 +143,7 @@ internal class PeerBootstrapService : BackgroundService
                             MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                             MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
 
-                            MaxIdleTimeout = 10_000,
+                            MaxIdleTimeout = 20_000,
                         };
 
                         clientConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/PeerBootstrapService.cs
+++ b/Subverse.Server/PeerBootstrapService.cs
@@ -142,8 +142,6 @@ internal class PeerBootstrapService : BackgroundService
                             MaxInitialBidiStreams = 16,
                             MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                             MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
-
-                            MaxIdleTimeout = 10_000,
                         };
 
                         clientConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/PeerBootstrapService.cs
+++ b/Subverse.Server/PeerBootstrapService.cs
@@ -142,6 +142,8 @@ internal class PeerBootstrapService : BackgroundService
                             MaxInitialBidiStreams = 16,
                             MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                             MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
+
+                            MaxIdleTimeout = 30_000,
                         };
 
                         clientConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/PeerBootstrapService.cs
+++ b/Subverse.Server/PeerBootstrapService.cs
@@ -143,7 +143,7 @@ internal class PeerBootstrapService : BackgroundService
                             MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                             MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
 
-                            MaxIdleTimeout = 30_000,
+                            MaxIdleTimeout = 10_000,
                         };
 
                         clientConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/PeerBootstrapService.cs
+++ b/Subverse.Server/PeerBootstrapService.cs
@@ -142,8 +142,6 @@ internal class PeerBootstrapService : BackgroundService
                             MaxInitialBidiStreams = 16,
                             MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                             MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
-
-                            MaxIdleTimeout = 10000,
                         };
 
                         clientConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/PeerBootstrapService.cs
+++ b/Subverse.Server/PeerBootstrapService.cs
@@ -123,9 +123,8 @@ internal class PeerBootstrapService : BackgroundService
 
                     if (remoteEndPoint is null ||
                             _connectionMap.TryGetValue(hostname, out IPeerConnection? currentPeerConnection) &&
-                            (!currentPeerConnection.HasValidConnectionTo(_peerService.PeerId) &&
-                            _connectionMap.TryRemove(hostname, out IPeerConnection? _) ||
-                            currentPeerConnection.HasValidConnectionTo(_peerService.PeerId)))
+                            !currentPeerConnection.HasValidConnectionTo(_peerService.PeerId) &&
+                            _connectionMap.TryRemove(hostname, out IPeerConnection? _))
                     {
                         continue;
                     }

--- a/Subverse.Server/PeerBootstrapService.cs
+++ b/Subverse.Server/PeerBootstrapService.cs
@@ -142,6 +142,8 @@ internal class PeerBootstrapService : BackgroundService
                             MaxInitialBidiStreams = 16,
                             MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                             MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
+
+                            MaxIdleTimeout = 10000,
                         };
 
                         clientConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/PeerBootstrapService.cs
+++ b/Subverse.Server/PeerBootstrapService.cs
@@ -143,7 +143,7 @@ internal class PeerBootstrapService : BackgroundService
                             MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                             MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
 
-                            MaxIdleTimeout = 45_000,
+                            MaxIdleTimeout = 10_000,
                         };
 
                         clientConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -68,7 +68,7 @@ namespace Subverse.Server
                 MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                 MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
 
-                MaxIdleTimeout = 30_000,
+                MaxIdleTimeout = 10_000,
             };
 
             serverConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -70,9 +70,7 @@ namespace Subverse.Server
 
                     MaxInitialBidiStreams = 16,
                     MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
-                    MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
-
-                    MaxIdleTimeout = 10000,
+                    MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN
                 };
 
                 serverConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -68,7 +68,7 @@ namespace Subverse.Server
                 MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                 MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
 
-                MaxIdleTimeout = 30_000,
+                MaxIdleTimeout = 60_000,
             };
 
             serverConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -58,67 +58,60 @@ namespace Subverse.Server
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
-                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ||
-                RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            var initialData = new byte[QuicheLibrary.MAX_DATAGRAM_LEN];
+
+            var serverConfig = new QuicheConfig()
             {
-                var initialData = new byte[QuicheLibrary.MAX_DATAGRAM_LEN];
+                MaxInitialDataSize = QuicheLibrary.MAX_BUFFER_LEN,
 
-                var serverConfig = new QuicheConfig()
+                MaxInitialBidiStreams = 16,
+                MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
+                MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN
+            };
+
+            serverConfig.SetApplicationProtocols("SubverseV2");
+
+            string certChainPath = _configuration.GetSection("Privacy")
+                .GetValue<string>("SSLCertChainPath") ?? DEFAULT_CERT_CHAIN_PATH;
+            serverConfig.LoadCertificateChainFromPemFile(
+                Path.IsPathFullyQualified(certChainPath) ? certChainPath :
+                Path.Combine(_environment.ContentRootPath, certChainPath)
+                );
+
+            string privateKeyPath = _configuration.GetSection("Privacy")
+                .GetValue<string>("SSLPrivateKeyPath") ?? DEFAULT_PRIVATE_KEY_PATH;
+            serverConfig.LoadPrivateKeyFromPemFile(
+                Path.IsPathFullyQualified(privateKeyPath) ? privateKeyPath :
+                Path.Combine(_environment.ContentRootPath, privateKeyPath)
+                );
+
+            List<Task> listenTasks = new();
+            try
+            {
+                using var socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
+                socket.Bind(new IPEndPoint(IPAddress.Any, 0));
+
+                _peerService.LocalEndPoint = socket.LocalEndPoint as IPEndPoint;
+
+                using var listener = new QuicheListener(socket, serverConfig);
+                _ = listener.ListenAsync(stoppingToken);
+
+                while (!stoppingToken.IsCancellationRequested)
                 {
-                    MaxInitialDataSize = QuicheLibrary.MAX_BUFFER_LEN,
+                    stoppingToken.ThrowIfCancellationRequested();
 
-                    MaxInitialBidiStreams = 16,
-                    MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
-                    MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
-
-                    MaxIdleTimeout = 10_000,
-                };
-
-                serverConfig.SetApplicationProtocols("SubverseV2");
-
-                string certChainPath = _configuration.GetSection("Privacy")
-                    .GetValue<string>("SSLCertChainPath") ?? DEFAULT_CERT_CHAIN_PATH;
-                serverConfig.LoadCertificateChainFromPemFile(
-                    Path.IsPathFullyQualified(certChainPath) ? certChainPath :
-                    Path.Combine(_environment.ContentRootPath, certChainPath)
-                    );
-
-                string privateKeyPath = _configuration.GetSection("Privacy")
-                    .GetValue<string>("SSLPrivateKeyPath") ?? DEFAULT_PRIVATE_KEY_PATH;
-                serverConfig.LoadPrivateKeyFromPemFile(
-                    Path.IsPathFullyQualified(privateKeyPath) ? privateKeyPath :
-                    Path.Combine(_environment.ContentRootPath, privateKeyPath)
-                    );
-
-                List<Task> listenTasks = new();
-                try
-                {
-                    using var socket = new Socket(SocketType.Dgram, ProtocolType.Udp);
-                    socket.Bind(new IPEndPoint(IPAddress.Any, 0));
-
-                    _peerService.LocalEndPoint = socket.LocalEndPoint as IPEndPoint;
-
-                    using var listener = new QuicheListener(socket, serverConfig);
-                    _ = listener.ListenAsync(stoppingToken);
-
-                    while (!stoppingToken.IsCancellationRequested)
-                    {
-                        stoppingToken.ThrowIfCancellationRequested();
-
-                        var quicheConnection = await listener.AcceptAsync(stoppingToken);
-                        var listenTask = Task.Run(() => ListenConnectionsAsync(quicheConnection, stoppingToken));
-                        listenTasks.Add(listenTask);
-                    }
+                    var quicheConnection = await listener.AcceptAsync(stoppingToken);
+                    var listenTask = Task.Run(() => ListenConnectionsAsync(quicheConnection, stoppingToken));
+                    listenTasks.Add(listenTask);
                 }
-                catch (OperationCanceledException) { }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, null);
-                }
-
-                await Task.WhenAll(listenTasks);
             }
+            catch (OperationCanceledException) { }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, null);
+            }
+
+            await Task.WhenAll(listenTasks);
         }
     }
 }

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -67,6 +67,8 @@ namespace Subverse.Server
                 MaxInitialBidiStreams = 16,
                 MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                 MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
+
+                MaxIdleTimeout = 15_000,
             };
 
             serverConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -72,7 +72,7 @@ namespace Subverse.Server
                     MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                     MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
 
-                    MaxIdleTimeout = 15_000,
+                    MaxIdleTimeout = 10_000,
                 };
 
                 serverConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -16,22 +16,22 @@ namespace Subverse.Server
         private readonly IConfiguration _configuration;
 
         private readonly ILogger<QuicheListenerService> _logger;
-        private readonly ILoggerProvider _loggerProvider;
+        private readonly ILoggerFactory _loggerFactory;
         private readonly IPeerService _peerService;
 
-        public QuicheListenerService(IHostEnvironment environment, IConfiguration configuration, ILogger<QuicheListenerService> logger, ILoggerProvider loggerProvider, IPeerService hubService)
+        public QuicheListenerService(IHostEnvironment environment, IConfiguration configuration, ILogger<QuicheListenerService> logger, ILoggerFactory loggerFactory, IPeerService hubService)
         {
             _environment = environment;
             _configuration = configuration;
 
             _logger = logger;
-            _loggerProvider = loggerProvider;
+            _loggerFactory = loggerFactory;
             _peerService = hubService;
         }
 
         private async Task ListenConnectionsAsync(QuicheConnection quicheConnection, CancellationToken cancellationToken)
         {
-            var peerConnection = new QuichePeerConnection(_loggerProvider.CreateLogger("QuicheConnection"), quicheConnection);
+            var peerConnection = new QuichePeerConnection(_loggerFactory.CreateLogger<QuichePeerConnection>(), quicheConnection);
             List<SubversePeerId> connectionIds = new();
             try
             {

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -67,8 +67,6 @@ namespace Subverse.Server
                 MaxInitialBidiStreams = 16,
                 MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                 MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
-
-                MaxIdleTimeout = 30_000,
             };
 
             serverConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -68,7 +68,7 @@ namespace Subverse.Server
                 MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                 MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
 
-                MaxIdleTimeout = 15_000,
+                MaxIdleTimeout = 45_000,
             };
 
             serverConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -70,7 +70,9 @@ namespace Subverse.Server
 
                     MaxInitialBidiStreams = 16,
                     MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
-                    MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN
+                    MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
+
+                    MaxIdleTimeout = 15_000,
                 };
 
                 serverConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -67,8 +67,6 @@ namespace Subverse.Server
                 MaxInitialBidiStreams = 16,
                 MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                 MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
-
-                MaxIdleTimeout = 10_000,
             };
 
             serverConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -67,10 +67,12 @@ namespace Subverse.Server
                 MaxInitialBidiStreams = 16,
                 MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                 MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
+
+                MaxIdleTimeout = 30_000,
             };
 
             serverConfig.SetApplicationProtocols("SubverseV2");
-
+             
             string certChainPath = _configuration.GetSection("Privacy")
                 .GetValue<string>("SSLCertChainPath") ?? DEFAULT_CERT_CHAIN_PATH;
             serverConfig.LoadCertificateChainFromPemFile(

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -68,7 +68,7 @@ namespace Subverse.Server
                 MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                 MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
 
-                MaxIdleTimeout = 20_000,
+                MaxIdleTimeout = 30_000,
             };
 
             serverConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -68,7 +68,7 @@ namespace Subverse.Server
                 MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                 MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
 
-                MaxIdleTimeout = 45_000,
+                MaxIdleTimeout = 10_000,
             };
 
             serverConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -71,6 +71,8 @@ namespace Subverse.Server
                     MaxInitialBidiStreams = 16,
                     MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                     MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
+
+                    MaxIdleTimeout = 10000,
                 };
 
                 serverConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -68,7 +68,7 @@ namespace Subverse.Server
                 MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                 MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
 
-                MaxIdleTimeout = 10_000,
+                MaxIdleTimeout = 20_000,
             };
 
             serverConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -66,7 +66,9 @@ namespace Subverse.Server
 
                 MaxInitialBidiStreams = 16,
                 MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
-                MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN
+                MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
+
+                MaxIdleTimeout = 10_000,
             };
 
             serverConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -67,8 +67,6 @@ namespace Subverse.Server
                 MaxInitialBidiStreams = 16,
                 MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                 MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
-
-                MaxIdleTimeout = 15_000,
             };
 
             serverConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/QuicheListenerService.cs
+++ b/Subverse.Server/QuicheListenerService.cs
@@ -67,6 +67,8 @@ namespace Subverse.Server
                 MaxInitialBidiStreams = 16,
                 MaxInitialLocalBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
                 MaxInitialRemoteBidiStreamDataSize = QuicheLibrary.MAX_BUFFER_LEN,
+
+                MaxIdleTimeout = 30_000,
             };
 
             serverConfig.SetApplicationProtocols("SubverseV2");

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -67,7 +67,7 @@ namespace Subverse.Server
             {
                 byte[]? rawMessageBytes = null;
 
-                Span<byte> rawMessageCountBytes = stackalloc byte[sizeof(int)];
+                byte[] rawMessageCountBytes = new byte[sizeof(int)];
                 ref int rawMessageCount = ref MemoryMarshal.AsRef<int>(rawMessageCountBytes);
 
                 try
@@ -78,7 +78,7 @@ namespace Subverse.Server
 
                         for (int readCount = 0; readCount < sizeof(int);)
                         {
-                            int justRead = quicheStream.Read(rawMessageCountBytes.Slice(readCount));
+                            int justRead = quicheStream.Read(rawMessageCountBytes.AsSpan(readCount));
                             readCount += justRead;
                             if (justRead == 0 && quicheStream.CanRead)
                             {

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -65,7 +65,7 @@ namespace Subverse.Server
 
                             if (!quicheStream.CanRead) throw new NotSupportedException("Stream cannot be read from at this time.");
 
-                            string? jsonMessage = await streamReader.ReadLineAsync(cancellationToken);
+                            string? jsonMessage = await streamReader.ReadToEndAsync(cancellationToken);
                             if (jsonMessage is not null)
                             {
                                 var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage, new PeerIdConverter()) ??

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -72,7 +72,7 @@ namespace Subverse.Server
                             {
                                 rawMessageCountBytes[i++] = (byte)value;
                             }
-                            else { await Task.Yield(); }
+                            else { await Task.Delay(75); }
                         }
                         int rawMessageCount = BitConverter.ToInt32(rawMessageCountBytes);
 
@@ -84,7 +84,7 @@ namespace Subverse.Server
                             {
                                 readCount += justRead;
                             }
-                            else { await Task.Yield(); }
+                            else { await Task.Delay(75); }
                         }
 
                         using MemoryStream rawMessageStream = new(rawMessageBytes);

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -67,15 +67,10 @@ namespace Subverse.Server
                         try
                         {
                             int rawMessageCount = binaryReader.ReadInt32();
-                            byte[] rawMessageBytes = binaryReader.ReadBytes(++rawMessageCount);
-
-                            if (rawMessageBytes.Length < rawMessageCount) 
-                            {
-                                throw new EndOfStreamException();
-                            }
+                            byte[] rawMessageBytes = new byte[++rawMessageCount];
+                            quicheStream.ReadExactly(rawMessageBytes);
 
                             using MemoryStream rawMessageStream = new(rawMessageBytes);
-
                             using BsonDataReader bsonReader = new(rawMessageStream);
                             JsonSerializer serializer = new()
                             {

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -65,10 +65,10 @@ namespace Subverse.Server
 
                             if (!quicheStream.CanRead) throw new NotSupportedException("Stream cannot be read from at this time.");
 
-                            string? jsonMessage = await streamReader.ReadToEndAsync(cancellationToken);
+                            string? jsonMessage = await streamReader.ReadLineAsync(cancellationToken);
                             if (!string.IsNullOrEmpty(jsonMessage))
                             {
-                                var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage, new PeerIdConverter()) ??
+                                var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage.Trim('\r'), new PeerIdConverter()) ??
                                         throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
 
                                 _initialMessageSource.TrySetResult(message);

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -240,7 +240,7 @@ namespace Subverse.Server
             using (var streamWriter = new StreamWriter(quicheStream, Encoding.UTF8, leaveOpen: true))
             {
                 string jsonMessage = JsonConvert.SerializeObject(message, new PeerIdConverter());
-                streamWriter.Write(jsonMessage);
+                streamWriter.WriteLine(jsonMessage);
             }
         }
 

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -57,15 +57,14 @@ namespace Subverse.Server
             {
                 try
                 {
+                    using StreamReader streamReader = new (quicheStream, Encoding.UTF8, leaveOpen: true);
                     while (!cancellationToken.IsCancellationRequested)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
                         if (!quicheStream.CanRead) throw new NotSupportedException("Stream cannot be read from at this time.");
 
-                        using StreamReader streamReader = new (quicheStream, Encoding.UTF8, leaveOpen: true);
-                        string? jsonMessage = await streamReader.ReadLineAsync(cancellationToken);
-
+                        string? jsonMessage = (await streamReader.ReadLineAsync(cancellationToken))?.TrimStart('\uFEFF');
                         if (jsonMessage is not null)
                         {
                             _logger.LogDebug($"Got JSON:\n{jsonMessage}");

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -68,6 +68,12 @@ namespace Subverse.Server
                         {
                             int rawMessageCount = binaryReader.ReadInt32();
                             byte[] rawMessageBytes = binaryReader.ReadBytes(++rawMessageCount);
+
+                            if (rawMessageBytes.Length < rawMessageCount) 
+                            {
+                                throw new EndOfStreamException();
+                            }
+
                             using MemoryStream rawMessageStream = new(rawMessageBytes);
 
                             using BsonDataReader bsonReader = new(rawMessageStream);

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -74,13 +74,13 @@ namespace Subverse.Server
                     {
                         try
                         {
-                            bsonReader.Read();
-
                             var message = serializer.Deserialize<SubverseMessage>(bsonReader) ??
                                 throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
 
                             _initialMessageSource.TrySetResult(message);
                             OnMessageRecieved(new MessageReceivedEventArgs(message));
+
+                            bsonReader.Read();
                         }
                         catch (JsonException) { await Task.Delay(150); }
 

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -70,8 +70,7 @@ namespace Subverse.Server
 
                 try
                 {
-                    while (!cancellationToken.IsCancellationRequested &&
-                        quicheStream.CanRead && bsonReader.Read())
+                    while (!cancellationToken.IsCancellationRequested && quicheStream.CanRead)
                     {
                         var message = serializer.Deserialize<SubverseMessage>(bsonReader)
                             ?? throw new InvalidOperationException(
@@ -82,6 +81,7 @@ namespace Subverse.Server
                         OnMessageRecieved(new MessageReceivedEventArgs(message));
 
                         cancellationToken.ThrowIfCancellationRequested();
+                        bsonReader.Read();
                     }
                 }
                 catch (OperationCanceledException)

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -65,7 +65,7 @@ namespace Subverse.Server
 
                             if (!quicheStream.CanRead) throw new NotSupportedException("Stream cannot be read from at this time.");
 
-                            string? jsonMessage = await streamReader.ReadLineAsync();
+                            string? jsonMessage = await streamReader.ReadLineAsync(cancellationToken);
                             if (jsonMessage is not null)
                             {
                                 var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage, new PeerIdConverter()) ??
@@ -75,9 +75,7 @@ namespace Subverse.Server
                                 OnMessageRecieved(new MessageReceivedEventArgs(message));
                             }
                             else 
-                            { 
-                                quicheStream.ReadByte(); 
-                                streamReader.DiscardBufferedData(); 
+                            {
                                 await Task.Delay(75, cancellationToken); 
                             }
                         }
@@ -243,7 +241,7 @@ namespace Subverse.Server
             using (var streamWriter = new StreamWriter(quicheStream, Encoding.UTF8, leaveOpen: true))
             {
                 string jsonMessage = JsonConvert.SerializeObject(message, new PeerIdConverter());
-                streamWriter.WriteLine(jsonMessage);
+                streamWriter.Write(jsonMessage);
             }
         }
 

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -68,6 +68,8 @@ namespace Subverse.Server
 
                         if (jsonMessage is not null)
                         {
+                            _logger.LogDebug($"Got JSON:\n{jsonMessage}");
+
                             var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage, new PeerIdConverter()) ??
                                     throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
 

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -67,7 +67,7 @@ namespace Subverse.Server
                         string? jsonMessage = (await streamReader.ReadLineAsync(cancellationToken))?.TrimStart('\uFEFF');
                         if (jsonMessage is not null)
                         {
-                            _logger.LogDebug($"Got JSON:\n{jsonMessage}");
+                            _logger.LogInformation($"Got JSON:\n{jsonMessage}");
 
                             var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage, new PeerIdConverter()) ??
                                     throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -74,13 +74,13 @@ namespace Subverse.Server
                     {
                         try
                         {
+                            bsonReader.Read();
+
                             var message = serializer.Deserialize<SubverseMessage>(bsonReader) ??
                                 throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
 
                             _initialMessageSource.TrySetResult(message);
                             OnMessageRecieved(new MessageReceivedEventArgs(message));
-
-                            bsonReader.Read();
                         }
                         catch (JsonException) { }
 

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -65,8 +65,10 @@ namespace Subverse.Server
 
                             if (!quicheStream.CanRead) throw new NotSupportedException("Stream cannot be read from at this time.");
 
-                            string jsonMessage = await streamReader.ReadToEndAsync();
-                            if (!string.IsNullOrEmpty(jsonMessage))
+                            string? jsonMessage = await streamReader.ReadLineAsync();
+                            streamReader.Read();
+
+                            if (jsonMessage is not null)
                             {
                                 var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage, new PeerIdConverter()) ??
                                         throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
@@ -238,7 +240,7 @@ namespace Subverse.Server
             using (var streamWriter = new StreamWriter(quicheStream, Encoding.UTF8, leaveOpen: true))
             {
                 string jsonMessage = JsonConvert.SerializeObject(message, new PeerIdConverter());
-                streamWriter.Write(jsonMessage);
+                streamWriter.WriteLine(jsonMessage);
             }
         }
 

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -65,9 +65,8 @@ namespace Subverse.Server
 
                             if (!quicheStream.CanRead) throw new NotSupportedException("Stream cannot be read from at this time.");
 
-                            string? jsonMessage = await streamReader.ReadLineAsync(cancellationToken);
-                            _logger.LogInformation($"Received JSON:\n{jsonMessage}");
-                            if (!string.IsNullOrWhiteSpace(jsonMessage))
+                            string? jsonMessage = (await streamReader.ReadLineAsync(cancellationToken))?.Trim();
+                            if (jsonMessage is not null)
                             {
                                 var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage, new PeerIdConverter()) ??
                                         throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -68,7 +68,12 @@ namespace Subverse.Server
                         {
                             int rawMessageCount = binaryReader.ReadInt32();
                             byte[] rawMessageBytes = new byte[++rawMessageCount];
-                            quicheStream.ReadExactly(rawMessageBytes);
+
+                            int readCount = 0;
+                            while (readCount < rawMessageCount) 
+                            {
+                                readCount += quicheStream.Read(rawMessageBytes.AsSpan(readCount));
+                            }
 
                             using MemoryStream rawMessageStream = new(rawMessageBytes);
                             using BsonDataReader bsonReader = new(rawMessageStream);

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -65,7 +65,7 @@ namespace Subverse.Server
 
                             if (!quicheStream.CanRead) throw new NotSupportedException("Stream cannot be read from at this time.");
 
-                            string? jsonMessage = (await streamReader.ReadLineAsync(cancellationToken))?.Trim();
+                            string? jsonMessage = await streamReader.ReadLineAsync(cancellationToken);
                             if (jsonMessage is not null)
                             {
                                 var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage, new PeerIdConverter()) ??
@@ -238,7 +238,7 @@ namespace Subverse.Server
             using (var streamWriter = new StreamWriter(quicheStream, Encoding.UTF8, leaveOpen: true))
             {
                 string jsonMessage = JsonConvert.SerializeObject(message, new PeerIdConverter());
-                streamWriter.WriteLine(jsonMessage);
+                streamWriter.Write(jsonMessage);
             }
         }
 

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -54,8 +54,7 @@ namespace Subverse.Server
         {
             return Task.Run(async Task? () =>
             {
-                using var bufferedStream = new BufferedStream(quicheStream);
-                using var bsonReader = new BsonDataReader(bufferedStream)
+                using var bsonReader = new BsonDataReader(quicheStream)
                 {
                     CloseInput = false,
                     SupportMultipleContent = true,

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -76,13 +76,13 @@ namespace Subverse.Server
 
                         try
                         {
-                            bsonReader.Read();
-
                             var message = serializer.Deserialize<SubverseMessage>(bsonReader) ??
                                     throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
 
                             _initialMessageSource.TrySetResult(message);
                             OnMessageRecieved(new MessageReceivedEventArgs(message));
+
+                            bsonReader.Read();
                         }
                         catch (JsonException) { await Task.Delay(75, cancellationToken); }
                     }

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -68,7 +68,7 @@ namespace Subverse.Server
                             string? jsonMessage = await streamReader.ReadToEndAsync(cancellationToken);
                             if (jsonMessage is not null)
                             {
-                                var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage, new PeerIdConverter()) ??
+                                var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage[..^2], new PeerIdConverter()) ??
                                         throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
 
                                 _initialMessageSource.TrySetResult(message);

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -86,15 +86,7 @@ namespace Subverse.Server
                 }
                 catch (OperationCanceledException)
                 {
-                    if (_initialMessageSource.Task.IsCompletedSuccessfully)
-                    {
-                        _logger.LogInformation($"Stopped receiving from proxy of {_initialMessageSource.Task.Result}.");
-                    }
-                    else
-                    {
-                        _initialMessageSource.TrySetCanceled(cancellationToken);
-                        _logger.LogInformation($"Stopped receiving from undesignated proxy.");
-                    }
+                    _initialMessageSource.TrySetCanceled(cancellationToken);
                     throw;
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
@@ -102,6 +94,17 @@ namespace Subverse.Server
                     _initialMessageSource.TrySetException(ex);
                     _logger.LogError(ex, null);
                     throw;
+                }
+                finally 
+                {
+                    if (_initialMessageSource.Task.IsCompletedSuccessfully)
+                    {
+                        _logger.LogInformation($"Stopped receiving from proxy of {_initialMessageSource.Task.Result}.");
+                    }
+                    else
+                    {
+                        _logger.LogInformation($"Stopped receiving from undesignated proxy.");
+                    }
                 }
             }, cancellationToken);
 

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -65,8 +65,8 @@ namespace Subverse.Server
 
                             if (!quicheStream.CanRead) throw new NotSupportedException("Stream cannot be read from at this time.");
 
-                            string? jsonMessage = await streamReader.ReadToEndAsync();
-                            if (jsonMessage is not null)
+                            string jsonMessage = await streamReader.ReadToEndAsync();
+                            if (!string.IsNullOrEmpty(jsonMessage))
                             {
                                 var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage, new PeerIdConverter()) ??
                                         throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -82,7 +82,7 @@ namespace Subverse.Server
                             _initialMessageSource.TrySetResult(message);
                             OnMessageRecieved(new MessageReceivedEventArgs(message));
                         }
-                        catch (JsonException) { }
+                        catch (JsonException) { await Task.Delay(75); }
 
                         cancellationToken.ThrowIfCancellationRequested();
                     }

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -68,7 +68,7 @@ namespace Subverse.Server
                             string? jsonMessage = await streamReader.ReadToEndAsync(cancellationToken);
                             if (!string.IsNullOrEmpty(jsonMessage))
                             {
-                                var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage[..^2], new PeerIdConverter()) ??
+                                var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage, new PeerIdConverter()) ??
                                         throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
 
                                 _initialMessageSource.TrySetResult(message);

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -121,6 +121,7 @@ namespace Subverse.Server
                         }
 
                         DEFAULT_ARRAY_POOL.Return(rawMessageBytes);
+                        rawMessageBytes = null;
                     }
                 }
                 catch (OperationCanceledException)
@@ -147,7 +148,7 @@ namespace Subverse.Server
 
                     if (rawMessageBytes is not null)
                     {
-                        ArrayPool<byte>.Shared.Return(rawMessageBytes);
+                        DEFAULT_ARRAY_POOL.Return(rawMessageBytes);
                     }
                 }
             }, cancellationToken);

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -74,13 +74,13 @@ namespace Subverse.Server
                     {
                         try
                         {
-                            bsonReader.Read();
-
                             var message = serializer.Deserialize<SubverseMessage>(bsonReader) ??
                                 throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
 
                             _initialMessageSource.TrySetResult(message);
                             OnMessageRecieved(new MessageReceivedEventArgs(message));
+
+                            bsonReader.Read();
                         }
                         catch (JsonException) { await Task.Delay(75); }
 

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -74,13 +74,13 @@ namespace Subverse.Server
                     {
                         try
                         {
+                            bsonReader.Read();
+
                             var message = serializer.Deserialize<SubverseMessage>(bsonReader) ??
                                 throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
 
                             _initialMessageSource.TrySetResult(message);
                             OnMessageRecieved(new MessageReceivedEventArgs(message));
-
-                            bsonReader.Read();
                         }
                         catch (JsonException) { await Task.Delay(150); }
 

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -74,15 +74,15 @@ namespace Subverse.Server
                     {
                         try
                         {
-                            bsonReader.Read();
-
                             var message = serializer.Deserialize<SubverseMessage>(bsonReader) ??
                                 throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
 
                             _initialMessageSource.TrySetResult(message);
                             OnMessageRecieved(new MessageReceivedEventArgs(message));
+
+                            bsonReader.Read();
                         }
-                        catch (JsonException) { await Task.Delay(75); }
+                        catch (JsonException) { await Task.Delay(150); }
 
                         cancellationToken.ThrowIfCancellationRequested();
                     }

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -72,13 +72,17 @@ namespace Subverse.Server
                 {
                     while (!cancellationToken.IsCancellationRequested && quicheStream.CanRead)
                     {
-                        var message = serializer.Deserialize<SubverseMessage>(bsonReader) ??
-                            throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
+                        try
+                        {
+                            var message = serializer.Deserialize<SubverseMessage>(bsonReader) ??
+                                throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
 
-                        _initialMessageSource.TrySetResult(message);
-                        OnMessageRecieved(new MessageReceivedEventArgs(message));
+                            _initialMessageSource.TrySetResult(message);
+                            OnMessageRecieved(new MessageReceivedEventArgs(message));
 
-                        bsonReader.Read();
+                            bsonReader.Read();
+                        }
+                        catch (JsonException) { }
 
                         cancellationToken.ThrowIfCancellationRequested();
                     }

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -66,9 +66,10 @@ namespace Subverse.Server
                             if (!quicheStream.CanRead) throw new NotSupportedException("Stream cannot be read from at this time.");
 
                             string? jsonMessage = await streamReader.ReadLineAsync(cancellationToken);
-                            if (!string.IsNullOrEmpty(jsonMessage))
+                            if (jsonMessage is not null)
                             {
-                                var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage.Trim('\r'), new PeerIdConverter()) ??
+                                _logger.LogInformation($"First character was: {(int)jsonMessage[0]}");
+                                var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage, new PeerIdConverter()) ??
                                         throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
 
                                 _initialMessageSource.TrySetResult(message);

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -66,8 +66,6 @@ namespace Subverse.Server
                             if (!quicheStream.CanRead) throw new NotSupportedException("Stream cannot be read from at this time.");
 
                             string? jsonMessage = await streamReader.ReadLineAsync();
-                            streamReader.Read();
-
                             if (jsonMessage is not null)
                             {
                                 var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage, new PeerIdConverter()) ??
@@ -76,7 +74,7 @@ namespace Subverse.Server
                                 _initialMessageSource.TrySetResult(message);
                                 OnMessageRecieved(new MessageReceivedEventArgs(message));
                             }
-                            else { await Task.Delay(75, cancellationToken); }
+                            else { streamReader.Read(); await Task.Delay(75, cancellationToken); }
                         }
                     }
                 }

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -80,7 +80,7 @@ namespace Subverse.Server
                             readCount += justRead;
                             if (justRead == 0 && quicheStream.CanRead)
                             {
-                                await Task.Delay(75, cancellationToken);
+                                await Task.Delay(150, cancellationToken);
                             }
                             else if (!quicheStream.CanRead)
                             {
@@ -97,7 +97,7 @@ namespace Subverse.Server
                             readCount += justRead;
                             if (justRead == 0 && quicheStream.CanRead)
                             {
-                                await Task.Delay(75, cancellationToken);
+                                await Task.Delay(150, cancellationToken);
                             }
                             else if (!quicheStream.CanRead)
                             {

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -82,7 +82,7 @@ namespace Subverse.Server
                             _initialMessageSource.TrySetResult(message);
                             OnMessageRecieved(new MessageReceivedEventArgs(message));
                         }
-                        catch (JsonReaderException) { await Task.Delay(75); }
+                        catch (JsonException) { await Task.Delay(75); }
 
                         cancellationToken.ThrowIfCancellationRequested();
                     }

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -74,7 +74,12 @@ namespace Subverse.Server
                                 _initialMessageSource.TrySetResult(message);
                                 OnMessageRecieved(new MessageReceivedEventArgs(message));
                             }
-                            else { quicheStream.ReadByte(); await Task.Delay(75, cancellationToken); }
+                            else 
+                            { 
+                                quicheStream.ReadByte(); 
+                                streamReader.DiscardBufferedData(); 
+                                await Task.Delay(75, cancellationToken); 
+                            }
                         }
                     }
                 }

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -76,6 +76,8 @@ namespace Subverse.Server
 
                         try 
                         { 
+                            bsonReader.Read();
+
                             var message = serializer.Deserialize<SubverseMessage>(bsonReader) ??
                                     throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
 

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -78,14 +78,14 @@ namespace Subverse.Server
                         {
                             _initialMessageSource.TrySetResult(message);
                             OnMessageRecieved(new MessageReceivedEventArgs(message));
+
+                            cancellationToken.ThrowIfCancellationRequested();
+                            bsonReader.Read();
                         }
                         else 
                         {
                             await Task.Delay(75, cancellationToken);
                         }
-
-                        cancellationToken.ThrowIfCancellationRequested();
-                        bsonReader.Read();
                     }
                 }
                 catch (OperationCanceledException)

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -72,17 +72,13 @@ namespace Subverse.Server
                 {
                     while (!cancellationToken.IsCancellationRequested && quicheStream.CanRead)
                     {
-                        try
-                        {
-                            var message = serializer.Deserialize<SubverseMessage>(bsonReader) ??
-                                throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
+                        var message = serializer.Deserialize<SubverseMessage>(bsonReader) ??
+                            throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
 
-                            _initialMessageSource.TrySetResult(message);
-                            OnMessageRecieved(new MessageReceivedEventArgs(message));
+                        _initialMessageSource.TrySetResult(message);
+                        OnMessageRecieved(new MessageReceivedEventArgs(message));
 
-                            bsonReader.Read();
-                        }
-                        catch (JsonException) { await Task.Delay(150); }
+                        bsonReader.Read();
 
                         cancellationToken.ThrowIfCancellationRequested();
                     }

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -63,8 +63,8 @@ namespace Subverse.Server
                         SupportMultipleContent = true,
                     };
 
-                    var serializer = new JsonSerializer() 
-                    { 
+                    var serializer = new JsonSerializer()
+                    {
                         Converters = { new PeerIdConverter() }
                     };
 
@@ -74,8 +74,8 @@ namespace Subverse.Server
 
                         if (!quicheStream.CanRead) throw new NotSupportedException("Stream cannot be read from at this time.");
 
-                        try 
-                        { 
+                        try
+                        {
                             bsonReader.Read();
 
                             var message = serializer.Deserialize<SubverseMessage>(bsonReader) ??
@@ -84,7 +84,7 @@ namespace Subverse.Server
                             _initialMessageSource.TrySetResult(message);
                             OnMessageRecieved(new MessageReceivedEventArgs(message));
                         }
-                        catch(JsonException) { await Task.Delay(75, cancellationToken); }
+                        catch (JsonException) { await Task.Delay(75, cancellationToken); }
                     }
                 }
                 catch (OperationCanceledException)

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -75,7 +75,7 @@ namespace Subverse.Server
                         try
                         {
                             var message = serializer.Deserialize<SubverseMessage>(bsonReader) ??
-                                throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
+                                throw new JsonException("Expected SubverseMessage, got malformed data instead!");
 
                             _initialMessageSource.TrySetResult(message);
                             OnMessageRecieved(new MessageReceivedEventArgs(message));

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -66,7 +66,7 @@ namespace Subverse.Server
                             if (!quicheStream.CanRead) throw new NotSupportedException("Stream cannot be read from at this time.");
 
                             string? jsonMessage = await streamReader.ReadLineAsync(cancellationToken);
-                            if (jsonMessage is not null)
+                            if (!string.IsNullOrWhiteSpace(jsonMessage))
                             {
                                 var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage, new PeerIdConverter()) ??
                                         throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -88,7 +88,7 @@ namespace Subverse.Server
                             }
                         }
 
-                        rawMessageCount = BitConverter.ToInt32(rawMessageBytes);
+                        rawMessageCount = BitConverter.ToInt32(rawMessageCountBytes);
                         rawMessageBytes = DEFAULT_ARRAY_POOL.Rent(++rawMessageCount);
 
                         for (int readCount = 0; readCount < rawMessageCount;)

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -74,13 +74,13 @@ namespace Subverse.Server
                     {
                         try
                         {
+                            bsonReader.Read();
+
                             var message = serializer.Deserialize<SubverseMessage>(bsonReader) ??
-                                throw new JsonException("Expected SubverseMessage, got malformed data instead!");
+                                throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
 
                             _initialMessageSource.TrySetResult(message);
                             OnMessageRecieved(new MessageReceivedEventArgs(message));
-
-                            bsonReader.Read();
                         }
                         catch (JsonException) { await Task.Delay(75); }
 

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -75,15 +75,14 @@ namespace Subverse.Server
                         try
                         {
                             bsonReader.Read();
-                            
+
                             var message = serializer.Deserialize<SubverseMessage>(bsonReader) ??
                                 throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
 
                             _initialMessageSource.TrySetResult(message);
                             OnMessageRecieved(new MessageReceivedEventArgs(message));
                         }
-                        catch (InvalidOperationException) { }
-                        catch (JsonReaderException) { }
+                        catch (JsonReaderException) { await Task.Delay(75); }
 
                         cancellationToken.ThrowIfCancellationRequested();
                     }
@@ -103,7 +102,7 @@ namespace Subverse.Server
                 {
                     if (_initialMessageSource.Task.IsCompletedSuccessfully)
                     {
-                        _logger.LogInformation($"Stopped receiving from proxy of {_initialMessageSource.Task.Result}.");
+                        _logger.LogInformation($"Stopped receiving from proxy of {_initialMessageSource.Task.Result.Recipient}.");
                     }
                     else
                     {

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -66,6 +66,7 @@ namespace Subverse.Server
                             if (!quicheStream.CanRead) throw new NotSupportedException("Stream cannot be read from at this time.");
 
                             string? jsonMessage = await streamReader.ReadLineAsync(cancellationToken);
+                            _logger.LogInformation($"Received JSON:\n{jsonMessage}");
                             if (!string.IsNullOrWhiteSpace(jsonMessage))
                             {
                                 var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage, new PeerIdConverter()) ??

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -74,7 +74,7 @@ namespace Subverse.Server
                                 _initialMessageSource.TrySetResult(message);
                                 OnMessageRecieved(new MessageReceivedEventArgs(message));
                             }
-                            else { streamReader.Read(); await Task.Delay(75, cancellationToken); }
+                            else { quicheStream.ReadByte(); await Task.Delay(75, cancellationToken); }
                         }
                     }
                 }

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -65,7 +65,7 @@ namespace Subverse.Server
 
                             if (!quicheStream.CanRead) throw new NotSupportedException("Stream cannot be read from at this time.");
 
-                            string? jsonMessage = await streamReader.ReadLineAsync(cancellationToken);
+                            string? jsonMessage = await streamReader.ReadToEndAsync();
                             if (jsonMessage is not null)
                             {
                                 var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage, new PeerIdConverter()) ??

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -66,7 +66,7 @@ namespace Subverse.Server
                             if (!quicheStream.CanRead) throw new NotSupportedException("Stream cannot be read from at this time.");
 
                             string? jsonMessage = await streamReader.ReadToEndAsync(cancellationToken);
-                            if (jsonMessage is not null)
+                            if (!string.IsNullOrEmpty(jsonMessage))
                             {
                                 var message = JsonConvert.DeserializeObject<SubverseMessage>(jsonMessage[..^2], new PeerIdConverter()) ??
                                         throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -75,7 +75,7 @@ namespace Subverse.Server
                         try
                         {
                             var message = serializer.Deserialize<SubverseMessage>(bsonReader) ??
-                                throw new JsonException("Expected SubverseMessage, got malformed data instead!");
+                                throw new InvalidOperationException("Expected SubverseMessage, got malformed data instead!");
 
                             _initialMessageSource.TrySetResult(message);
                             OnMessageRecieved(new MessageReceivedEventArgs(message));

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -66,16 +66,14 @@ namespace Subverse.Server
             return Task.Run(async Task? () =>
             {
                 byte[]? rawMessageBytes = null;
-
                 byte[] rawMessageCountBytes = new byte[sizeof(int)];
-                ref int rawMessageCount = ref MemoryMarshal.AsRef<int>(rawMessageCountBytes);
-
                 try
                 {
                     while (!cancellationToken.IsCancellationRequested)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
 
+                        int rawMessageCount;
                         for (int readCount = 0; readCount < sizeof(int);)
                         {
                             int justRead = quicheStream.Read(rawMessageCountBytes.AsSpan(readCount));
@@ -90,7 +88,9 @@ namespace Subverse.Server
                             }
                         }
 
+                        rawMessageCount = BitConverter.ToInt32(rawMessageBytes);
                         rawMessageBytes = DEFAULT_ARRAY_POOL.Rent(++rawMessageCount);
+
                         for (int readCount = 0; readCount < rawMessageCount;)
                         {
                             int justRead = quicheStream.Read(rawMessageBytes.AsSpan(readCount, rawMessageCount - readCount));

--- a/Subverse.Server/QuichePeerConnection.cs
+++ b/Subverse.Server/QuichePeerConnection.cs
@@ -13,7 +13,7 @@ namespace Subverse.Server
     {
         public static int DEFAULT_CONFIG_START_TTL = 99;
 
-        private readonly ILogger _logger;
+        private readonly ILogger<QuichePeerConnection> _logger;
 
         private readonly QuicheConnection _connection;
 
@@ -27,7 +27,7 @@ namespace Subverse.Server
 
         public event EventHandler<MessageReceivedEventArgs>? MessageReceived;
 
-        public QuichePeerConnection(ILogger logger, QuicheConnection connection)
+        public QuichePeerConnection(ILogger<QuichePeerConnection> logger, QuicheConnection connection)
         {
             _logger = logger;
             _connection = connection;

--- a/Subverse.Server/RoutedPeerService.cs
+++ b/Subverse.Server/RoutedPeerService.cs
@@ -329,11 +329,16 @@ namespace Subverse.Server
         {
             if (message.TimeToLive <= 0) return;
 
-            HashSet<IPeerConnection> connections = _connectionMap.Values
-                .FlattenWithLock<
-                    HashSet<IPeerConnection>,
-                    IPeerConnection>()
-                .ToHashSet();
+            HashSet<IPeerConnection>? connections;
+            if (!_connectionMap.TryGetValue(message.Recipient,
+                out connections) || connections.Count == 0)
+            {
+                connections = _connectionMap.Values
+                    .FlattenWithLock<
+                        HashSet<IPeerConnection>,
+                        IPeerConnection>()
+                    .ToHashSet();
+            }
 
             using CancellationTokenSource cts = new();
             CancellationToken cancellationToken = cts.Token;

--- a/Subverse.Server/RoutedPeerService.cs
+++ b/Subverse.Server/RoutedPeerService.cs
@@ -330,15 +330,15 @@ namespace Subverse.Server
             if (message.TimeToLive <= 0) return;
 
             HashSet<IPeerConnection>? connections;
-            //if (!_connectionMap.TryGetValue(message.Recipient,
-            //    out connections) || connections.Count == 0)
-            //{
+            if (!_connectionMap.TryGetValue(message.Recipient,
+                out connections) || connections.Count == 0)
+            {
                 connections = _connectionMap.Values
                     .FlattenWithLock<
                         HashSet<IPeerConnection>,
                         IPeerConnection>()
                     .ToHashSet();
-            //}
+            }
 
             using CancellationTokenSource cts = new();
             CancellationToken cancellationToken = cts.Token;

--- a/Subverse.Server/RoutedPeerService.cs
+++ b/Subverse.Server/RoutedPeerService.cs
@@ -329,16 +329,11 @@ namespace Subverse.Server
         {
             if (message.TimeToLive <= 0) return;
 
-            HashSet<IPeerConnection>? connections;
-            if (!_connectionMap.TryGetValue(message.Recipient,
-                out connections) || connections.Count == 0)
-            {
-                connections = _connectionMap.Values
-                    .FlattenWithLock<
-                        HashSet<IPeerConnection>,
-                        IPeerConnection>()
-                    .ToHashSet();
-            }
+            HashSet<IPeerConnection> connections = _connectionMap.Values
+                .FlattenWithLock<
+                    HashSet<IPeerConnection>,
+                    IPeerConnection>()
+                .ToHashSet();
 
             using CancellationTokenSource cts = new();
             CancellationToken cancellationToken = cts.Token;

--- a/Subverse.Server/RoutedPeerService.cs
+++ b/Subverse.Server/RoutedPeerService.cs
@@ -330,15 +330,15 @@ namespace Subverse.Server
             if (message.TimeToLive <= 0) return;
 
             HashSet<IPeerConnection>? connections;
-            if (!_connectionMap.TryGetValue(message.Recipient,
-                out connections) || connections.Count == 0)
-            {
+            //if (!_connectionMap.TryGetValue(message.Recipient,
+            //    out connections) || connections.Count == 0)
+            //{
                 connections = _connectionMap.Values
                     .FlattenWithLock<
                         HashSet<IPeerConnection>,
                         IPeerConnection>()
                     .ToHashSet();
-            }
+            //}
 
             using CancellationTokenSource cts = new();
             CancellationToken cancellationToken = cts.Token;

--- a/Subverse.Server/Subverse.Server.csproj
+++ b/Subverse.Server/Subverse.Server.csproj
@@ -5,6 +5,7 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>e4b12c90-b56a-4770-9925-732c45eddb46</UserSecretsId>
+		<LangVersion>preview</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
I've isolated the issue of bidirectional streams to be caused by some implementation-specific behavior in quiche. 
This issue will be addressed in this PR by explicitly creating two streams, one for each direction of communication. 

While this was attempted in previous PRs, those PRs also had significant bugs in how the internal Quiche.NET stream logic operated. Now, reimplementing this behavior should actually work. 